### PR TITLE
chore: Use verified publisher image hashicorp/vault

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
 
     services:
       vault:
-        image: vault:${{ matrix.vault_version }}
+        image: hashicorp/vault:${{ matrix.vault_version }}
         env:
           SKIP_SETCAP: true
           VAULT_DEV_ROOT_TOKEN_ID: 227e1cce-6bf7-30bb-2d2a-acc854318caf

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   vault:
-    image: vault:1.13.3
+    image: hashicorp/vault:1.13.3
     ports:
       - 127.0.0.1:8200:8200
     environment:


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #58

Hashicorp has deprecated Duplicative Docker Images (see https://developer.hashicorp.com/vault/docs/v1.13.x/deprecation).
New versions of vault are only published to https://hub.docker.com/hashicorp/vault.
https://hub.docker.com/_/vault only contains old versions up to 1.13.3.

