### PR TITLE
Fix injecting versioned secrets from Vault secret path

### DIFF
--- a/internal/injector/injector.go
+++ b/internal/injector/injector.go
@@ -346,8 +346,8 @@ func (i *SecretInjector) InjectSecretsFromVaultPath(paths string, inject SecretI
 
 		version := "-1"
 
-		if len(split) > 2 {
-			version = split[2]
+		if len(split) == 2 {
+			version = split[1]
 		}
 
 		data, err := i.readVaultPath(valuePath, version, false)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes bank-vaults/internal#7 

Fix for versioned secret paths provided in `vault.security.banzaicloud.io/vault-env-from-path` annotation, also added test cases to cover versioned Vault secrets.

## Notes for reviewer

<!-- Anything the reviewer should know? -->
