### PR TITLE
fix: apply slogmulti.Router levelfilter equally

### DIFF
--- a/main.go
+++ b/main.go
@@ -158,7 +158,10 @@ func main() {
 
 		if cast.ToBool(os.Getenv("VAULT_JSON_LOG")) {
 			// Send logs with level higher than warning to stderr
-			router = router.Add(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+			router = router.Add(
+				slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}),
+				levelFilter(slog.LevelWarn, slog.LevelError),
+			)
 
 			// Send info and debug logs to stdout
 			router = router.Add(
@@ -167,7 +170,10 @@ func main() {
 			)
 		} else {
 			// Send logs with level higher than warning to stderr
-			router = router.Add(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+			router = router.Add(
+				slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}),
+				levelFilter(slog.LevelWarn, slog.LevelError),
+			)
 
 			// Send info and debug logs to stdout
 			router = router.Add(


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

In my experience from switching from `logrus` to `slog` in the webhook repo, we need to apply the `levelFilter` to warn and error logs as well, otherwise info and debug logs would be logged twice, on both routes.

Just an additional FYI: another issue was that in the previous version of `slog-multi`, the minimum `Level` defined in `slog.HandlerOptions` was not respected but it was fixed in v1.0.2 which this project already got updated to.
