### PR TITLE
chore: fix goreleaser make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,16 +77,18 @@ fmt: ## Format code
 
 ##@ Dependencies
 
-deps: bin/golangci-lint bin/licensei bin/goreleaser
+deps: bin/golangci-lint bin/cosign bin/licensei bin/goreleaser
 deps: ## Install dependencies
 
 # Dependency versions
 GOLANGCI_VERSION = 1.53.3
+COSIGN_VERSION = v2.2.2
 LICENSEI_VERSION = 0.8.0
 GORELEASER_VERSION = 1.18.2
 
 # Dependency binaries
 GOLANGCI_LINT_BIN := golangci-lint
+COSIGN_BIN := cosign
 LICENSEI_BIN := licensei
 GORELEASER_BIN := goreleaser
 
@@ -97,6 +99,7 @@ YAMLLINT_BIN := yamllint
 # If we have "bin" dir, use those binaries instead
 ifneq ($(wildcard ./bin/.),)
 	GOLANGCI_LINT_BIN := bin/$(GOLANGCI_LINT_BIN)
+	COSIGN_BIN := bin/$(COSIGN_BIN)
 	LICENSEI_BIN := bin/$(LICENSEI_BIN)
 	GORELEASER_BIN := bin/$(GORELEASER_BIN)
 endif
@@ -108,6 +111,20 @@ bin/golangci-lint:
 bin/licensei:
 	@mkdir -p bin
 	curl -sfL https://raw.githubusercontent.com/goph/licensei/master/install.sh | bash -s -- v${LICENSEI_VERSION}
+
+bin/cosign:
+	@mkdir -p bin
+	@OS=$$(uname -s); \
+    	if [ "$$OS" = "Linux" ]; then \
+    		curl -sSfL https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64 -o bin/cosign; \
+    	elif [ "$$OS" = "Darwin" ]; then \
+    		curl -sSfL https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-darwin-arm64 -o bin/cosign; \
+    	else \
+    		echo "Unsupported OS"; \
+    		exit 1; \
+    	fi
+	@chmod +x bin/cosign
+
 
 bin/goreleaser:
 	@mkdir -p bin

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ deps: ## Install dependencies
 
 # Dependency versions
 GOLANGCI_VERSION = 1.53.3
-COSIGN_VERSION = v2.2.2
+COSIGN_VERSION = 2.2.2
 LICENSEI_VERSION = 0.8.0
 GORELEASER_VERSION = 1.18.2
 
@@ -116,9 +116,9 @@ bin/cosign:
 	@mkdir -p bin
 	@OS=$$(uname -s); \
     	if [ "$$OS" = "Linux" ]; then \
-    		curl -sSfL https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-linux-amd64 -o bin/cosign; \
+    		curl -sSfL https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-amd64 -o bin/cosign; \
     	elif [ "$$OS" = "Darwin" ]; then \
-    		curl -sSfL https://github.com/sigstore/cosign/releases/download/${COSIGN_VERSION}/cosign-darwin-arm64 -o bin/cosign; \
+    		curl -sSfL https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-darwin-arm64 -o bin/cosign; \
     	else \
     		echo "Unsupported OS"; \
     		exit 1; \
@@ -127,8 +127,4 @@ bin/cosign:
 
 
 bin/goreleaser:
-	@mkdir -p bin
-	@mkdir -p tmpgoreleaser
-	curl -sfL https://goreleaser.com/static/run | VERSION=v${GORELEASER_VERSION} TMPDIR=${PWD}/tmpgoreleaser bash -s -- --version
-	mv tmpgoreleaser/goreleaser bin/
-	@rm -rf tmpgoreleaser
+	scripts/get-goreleaser.sh

--- a/scripts/get-goreleaser.sh
+++ b/scripts/get-goreleaser.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -e
+
+# Define the bin directory
+BIN_DIR="bin"
+
+# Create the bin directory if it doesn't exist
+mkdir -p "$BIN_DIR"
+
+if [[ "$VERSION" == *-pro ]]; then
+    DISTRIBUTION="pro"
+fi
+
+if test "$DISTRIBUTION" = "pro"; then
+    echo "Using Pro distribution..."
+    RELEASES_URL="https://github.com/goreleaser/goreleaser-pro/releases"
+    FILE_BASENAME="goreleaser-pro"
+    LATEST="$(curl -sf https://goreleaser.com/static/latest-pro)"
+else
+    echo "Using the OSS distribution..."
+    RELEASES_URL="https://github.com/goreleaser/goreleaser/releases"
+    FILE_BASENAME="goreleaser"
+    LATEST="$(curl -sf https://goreleaser.com/static/latest)"
+fi
+
+test -z "$VERSION" && VERSION="$LATEST"
+
+test -z "$VERSION" && {
+    echo "Unable to get goreleaser version." >&2
+    exit 1
+}
+
+if test "$DISTRIBUTION" = "pro" && [[ "$VERSION" != *-pro ]]; then
+    VERSION="$VERSION-pro"
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap "rm -rf \"$TMP_DIR\"" EXIT INT TERM
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+test "$ARCH" = "aarch64" && ARCH="arm64"
+TAR_FILE="${FILE_BASENAME}_${OS}_${ARCH}.tar.gz"
+
+(
+    cd "$TMP_DIR"
+    echo "Downloading GoReleaser $VERSION..."
+    curl -sfLO "$RELEASES_URL/download/$VERSION/$TAR_FILE"
+    curl -sfLO "$RELEASES_URL/download/$VERSION/checksums.txt"
+    echo "Verifying checksums..."
+    sha256sum --ignore-missing --quiet --check checksums.txt
+    if command -v cosign >/dev/null 2>&1; then
+        echo "Verifying signatures..."
+        cosign verify-blob \
+            --certificate-identity-regexp "https://github.com/goreleaser/goreleaser.*/.github/workflows/.*.yml@refs/tags/$VERSION" \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+            --cert "$RELEASES_URL/download/$VERSION/checksums.txt.pem" \
+            --signature "$RELEASES_URL/download/$VERSION/checksums.txt.sig" \
+            checksums.txt
+    else
+        echo "Could not verify signatures, cosign is not installed."
+    fi
+)
+
+tar -xf "$TMP_DIR/$TAR_FILE" -C "$TMP_DIR"
+mv "$TMP_DIR/goreleaser" "$BIN_DIR/"


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

make deps didn't work for me, so fixed by:
- Installing cosign which is required by goreleaser
- The goreleaser script installs and ran it ephemerally rather than saving it so the next step to rename it didn't work as it wasn't there.  I modified the script to save it and use this instead, ideally I tried to think of ways to avoid adding the scripts dir and the script but couldn't think of a way to do so following the current dependancy pattern.  


Fixes #(issue)

## Notes for reviewer


<!-- Anything the reviewer should know? -->
