### PR TITLE
chore: log SIGURG signals to debug

### DIFF
--- a/main.go
+++ b/main.go
@@ -361,6 +361,8 @@ func main() {
 				err := cmd.Process.Signal(sig)
 				if err != nil {
 					logger.Warn(fmt.Errorf("failed to signal process: %w", err).Error(), slog.String("signal", sig.String()))
+				} else if sig == syscall.SIGURG {
+					logger.Debug("received signal", slog.String("signal", sig.String()))
 				} else {
 					logger.Info("received signal", slog.String("signal", sig.String()))
 				}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Changed the log level in the signal handling loop to Debug when there's no errors. This is because the log is very spammy when running in daemon mode, this allows the setting of VAULT_LOG_LEVEL to Info to prevent this spam in stdout/logs


Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->
