### PR TITLE
fix: logs default to info and use env variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -149,7 +149,7 @@ func main() {
 		}
 
 		levelFilter := func(levels ...slog.Level) func(ctx context.Context, r slog.Record) bool {
-			return func(ctx context.Context, r slog.Record) bool {
+			return func(_ context.Context, r slog.Record) bool {
 				return slices.Contains(levels, r.Level)
 			}
 		}
@@ -159,25 +159,25 @@ func main() {
 		if cast.ToBool(os.Getenv("VAULT_JSON_LOG")) {
 			// Send logs with level higher than warning to stderr
 			router = router.Add(
-				slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}),
+				slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level}),
 				levelFilter(slog.LevelWarn, slog.LevelError),
 			)
 
 			// Send info and debug logs to stdout
 			router = router.Add(
-				slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}),
+				slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level}),
 				levelFilter(slog.LevelDebug, slog.LevelInfo),
 			)
 		} else {
 			// Send logs with level higher than warning to stderr
 			router = router.Add(
-				slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}),
+				slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}),
 				levelFilter(slog.LevelWarn, slog.LevelError),
 			)
 
 			// Send info and debug logs to stdout
 			router = router.Add(
-				slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}),
+				slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: level}),
 				levelFilter(slog.LevelDebug, slog.LevelInfo),
 			)
 		}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

The VAULT_LOG_LEVEL environment variable was ignored and slog was hardcoded to output debug logs, despite the code setting the default level to info.
I previously made a PR to change the SIGURG log spam to debug and released this change recently only to find the spam was still present because slog is hardcoded to output the debug logs.
Also changed unused ctx to _ so that golangci-lint would pass..



Fixes #(issue)

## Notes for reviewer
Added some slog messages to manually test
![image_2024-06-23_131040404](https://github.com/bank-vaults/vault-env/assets/46242388/88c0f781-57f5-4141-8748-a81d351471a8)

<!-- Anything the reviewer should know? -->
