### PR TITLE
build: reduce binary size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN go mod download
 
 COPY . .
 
-RUN go build -o /usr/local/bin/vault-env .
+RUN go build -ldflags "-s -w" -o /usr/local/bin/vault-env .
 RUN xx-verify /usr/local/bin/vault-env
 
 


### PR DESCRIPTION
add `-ldflags "-s -w"` to reduce binary size

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Updates the go build command to include the linker flags `-ldflags "-s -w"`, which strip debugging information and symbol tables from the resulting binary.

Reduces the binary size from 68MB to 48MB (Linux)

Kubernetes takes into account the resource requests of init containers even after they have completed. [issue](https://github.com/kubernetes/kubernetes/issues/124282)
When hundreds or even thousands of such containers are launched, this leads to an inaccurate counting of cluster resource usage, especially in cases where the main container's resource requests are lower than those of the init container.


## Notes for reviewer

<!-- Anything the reviewer should know? -->
