### PR TITLE
fix: Prevent panics when running in daemon mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -373,6 +373,7 @@ func main() {
 
 		err = cmd.Wait()
 
+		signal.Stop(sigs)
 		close(sigs)
 
 		if err != nil {


### PR DESCRIPTION
## Overview

This adds a missing `signal.Stop` before closing the signal channel; this prevents the `signal.Notify` goroutine from attempting to relay new signals in a closed channel. The following could be observed even when the application being wrapped (in daemon mode) exits with a successful status:

```
panic: send on closed channel

goroutine 73 [running]:
os/signal.process({0x1b60c68, 0x26262a8})
	/usr/local/go/src/os/signal/signal.go:245 +0x1a5
os/signal.loop()
	/usr/local/go/src/os/signal/signal_unix.go:23 +0x29
created by os/signal.Notify.func1.1 in goroutine 1
	/usr/local/go/src/os/signal/signal.go:151 +0x1f
```

Which lead the container to exit with a non-successful status.

## Notes for reviewer

N/A
